### PR TITLE
Fix class property issue in Python 3.5

### DIFF
--- a/CuraDrive/src/DrivePluginExtension.py
+++ b/CuraDrive/src/DrivePluginExtension.py
@@ -89,8 +89,6 @@ class DrivePluginExtension(QObject, Extension):
     def _updateMenuItems(self) -> None:
         """Update the menu items."""
         self.addMenuItem(Settings.translatable_messages["extension_menu_entry"], self.showDriveWindow)
-        if self.isLoggedIn:
-            self.addMenuItem(Settings.translatable_messages["extension_menu_entry_backup_now"], self.createBackup)
 
     def _autoBackup(self) -> None:
         """Automatically make a backup on boot if enabled."""

--- a/CuraDrive/src/Settings.py
+++ b/CuraDrive/src/Settings.py
@@ -36,7 +36,6 @@ class Settings:
         
         # Menu items.
         "extension_menu_entry": I18N_CATALOG.i18nc("@item:inmenu", "Open Cura Drive"),
-        "extension_menu_entry_backup_now": I18N_CATALOG.i18nc("@item:inmenu", "Backup Now"),
         
         # Notification messages.
         "backup_failed": I18N_CATALOG.i18nc("@info:backup_status", "There was an error while creating your backup."),


### PR DESCRIPTION
self.isLoggedIn gives issues in Python 3.5 as it's trying to access a class property before __init__has finished.
The menu item didn't work really smooth anyways (you had to be logged in when Cura starts) we just remove it for now.