### PR TITLE
Fix rendering issue with tooltip

### DIFF
--- a/CuraDrive/src/qml/components/ActionButton.qml
+++ b/CuraDrive/src/qml/components/ActionButton.qml
@@ -25,7 +25,7 @@ Button
         {
             id: buttonIcon
             iconSource: button.iconSource
-            width: 16
+            width: 16 * screenScaleFactor
             color: button.hovered ? button.textHoverColor : button.textColor
             visible: button.iconSource != "" && !loader.visible
         }
@@ -34,7 +34,7 @@ Button
         {
             id: loader
             iconSource: "../images/loading.gif"
-            width: 16
+            width: 16 * screenScaleFactor
             color: button.hovered ? button.textHoverColor : button.textColor
             visible: button.busy
             animated: true

--- a/CuraDrive/src/qml/components/ActionCheckBox.qml
+++ b/CuraDrive/src/qml/components/ActionCheckBox.qml
@@ -13,29 +13,33 @@ CheckBox
     property var label: ""
 
     indicator: Rectangle {
-        implicitWidth: 30
-        implicitHeight: 30
-        x: checkbox.leftPadding
-        y: parent.height / 2 - height / 2
+        implicitWidth: 30 * screenScaleFactor
+        implicitHeight: 30 * screenScaleFactor
+        x: 0
+        y: Math.round(parent.height / 2 - height / 2)
         color: UM.Theme.getColor("sidebar")
         border.color: UM.Theme.getColor("text")
 
         Rectangle {
-            width: 14
-            height: 14
-            x: 8
-            y: 8
+            width: 14 * screenScaleFactor
+            height: 14 * screenScaleFactor
+            x: 8 * screenScaleFactor
+            y: 8 * screenScaleFactor
             color: UM.Theme.getColor("primary")
             visible: checkbox.checked
         }
     }
 
     contentItem: Label {
+        anchors
+        {
+            left: checkbox.indicator.right
+            leftMargin: 5 * screenScaleFactor
+        }
         text: catalog.i18nc("@checkbox:description", "Auto Backup")
         color: UM.Theme.getColor("text")
         renderType: Text.NativeRendering
         verticalAlignment: Text.AlignVCenter
-        leftPadding: checkbox.indicator.width + 5
     }
 
     ActionToolTip

--- a/CuraDrive/src/qml/components/ActionToolTip.qml
+++ b/CuraDrive/src/qml/components/ActionToolTip.qml
@@ -16,7 +16,7 @@ ToolTip
     {
         color: UM.Theme.getColor("sidebar")
         border.color: UM.Theme.getColor("primary")
-        border.width: 1
+        border.width: 1 * screenScaleFactor
     }
 
     contentItem: Label

--- a/CuraDrive/src/qml/components/AvatarImage.qml
+++ b/CuraDrive/src/qml/components/AvatarImage.qml
@@ -7,8 +7,8 @@ Item
 {
     id: avatar
 
-    width: 96
-    height: 96
+    width: 96 * screenScaleFactor
+    height: 96 * screenScaleFactor
 
     property var source
 
@@ -29,7 +29,7 @@ Item
         source: "../images/inverted_circle.png"
         sourceSize: Qt.size(parent.width, parent.height)
         width: parent.width
-        height :parent.height
+        height: parent.height
         visible: false
     }
 

--- a/CuraDrive/src/qml/components/BackupListItem.qml
+++ b/CuraDrive/src/qml/components/BackupListItem.qml
@@ -27,7 +27,7 @@ Item
         id: dataRow
         spacing: UM.Theme.getSize("default_margin").width * 2
         width: parent.width
-        height: 50
+        height: 50 * screenScaleFactor
 
         ActionButton
         {
@@ -44,8 +44,8 @@ Item
             text: new Date(model["generated_time"]).toLocaleString(UM.Preferences.getValue("general/language"))
             color: UM.Theme.getColor("text")
             elide: Text.ElideRight
-            Layout.minimumWidth: 100
-            Layout.maximumWidth: 500
+            Layout.minimumWidth: 100 * screenScaleFactor
+            Layout.maximumWidth: 500 * screenScaleFactor
             Layout.fillWidth: true
             renderType: Text.NativeRendering
         }
@@ -55,8 +55,8 @@ Item
             text: model["data"]["description"]
             color: UM.Theme.getColor("text")
             elide: Text.ElideRight
-            Layout.minimumWidth: 100
-            Layout.maximumWidth: 500
+            Layout.minimumWidth: 100 * screenScaleFactor
+            Layout.maximumWidth: 500 * screenScaleFactor
             Layout.fillWidth: true
             renderType: Text.NativeRendering
         }

--- a/CuraDrive/src/qml/components/BackupListItemDetails.qml
+++ b/CuraDrive/src/qml/components/BackupListItemDetails.qml
@@ -9,7 +9,7 @@ ColumnLayout
 {
     id: backupDetails
     width: parent.width
-    spacing: 10
+    spacing: 10 * screenScaleFactor
     property var backupDetailsData
 
     // Cura version
@@ -56,6 +56,6 @@ ColumnLayout
     Item
     {
         width: parent.width
-        height: 10
+        height: 10 * screenScaleFactor
     }
 }

--- a/CuraDrive/src/qml/components/BackupListItemDetailsRow.qml
+++ b/CuraDrive/src/qml/components/BackupListItemDetailsRow.qml
@@ -9,7 +9,7 @@ RowLayout
 {
     id: detailsRow
     width: parent.width
-    height: 40
+    height: 40 * screenScaleFactor
 
     property var iconSource
     property var label
@@ -18,12 +18,12 @@ RowLayout
     // Spacing.
     Item
     {
-        width: 40
+        width: 40 * screenScaleFactor
     }
 
     Icon
     {
-        width: 18
+        width: 18 * screenScaleFactor
         iconSource: detailsRow.iconSource
         color: UM.Theme.getColor("text")
     }
@@ -33,8 +33,8 @@ RowLayout
         text: detailsRow.label
         color: UM.Theme.getColor("text")
         elide: Text.ElideRight
-        Layout.minimumWidth: 50
-        Layout.maximumWidth: 100
+        Layout.minimumWidth: 50 * screenScaleFactor
+        Layout.maximumWidth: 100 * screenScaleFactor
         Layout.fillWidth: true
         renderType: Text.NativeRendering
     }
@@ -44,8 +44,8 @@ RowLayout
         text: detailsRow.value
         color: UM.Theme.getColor("text")
         elide: Text.ElideRight
-        Layout.minimumWidth: 50
-        Layout.maximumWidth: 100
+        Layout.minimumWidth: 50 * screenScaleFactor
+        Layout.maximumWidth: 100 * screenScaleFactor
         Layout.fillWidth: true
         renderType: Text.NativeRendering
     }

--- a/CuraDrive/src/qml/components/ProfileDetails.qml
+++ b/CuraDrive/src/qml/components/ProfileDetails.qml
@@ -21,7 +21,7 @@ Item
 
         AvatarImage
         {
-            width: 64
+            width: 64 * screenScaleFactor
             height: width
             source: profile["profile_image_url"]
         }

--- a/CuraDrive/src/qml/pages/WelcomePage.qml
+++ b/CuraDrive/src/qml/pages/WelcomePage.qml
@@ -13,7 +13,7 @@ Column
     id: welcomePage
     spacing: UM.Theme.getSize("wide_margin").height
     width: parent.width
-    topPadding: 150
+    topPadding: 150 * screenScaleFactor
 
     Image
     {
@@ -21,14 +21,14 @@ Column
         fillMode: Image.PreserveAspectFit
         source: "../images/icon.png"
         anchors.horizontalCenter: parent.horizontalCenter
-        width: parent.width / 4
+        width: Math.round(parent.width / 4)
     }
 
     Label
     {
         id: welcomeTextLabel
         text: catalog.i18nc("@description", "Backup and synchronize your Cura settings.")
-        width: parent.width / 2
+        width: Math.round(parent.width / 2)
         font: UM.Theme.getFont("default")
         color: UM.Theme.getColor("text")
         verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
Fix an issue related with the rendering of the tooltip: text was wobbling (see below):

Before:
![image](https://user-images.githubusercontent.com/15830521/47366891-e3ef6180-d6de-11e8-9843-c82d5dc27fc2.png)

After:
![image](https://user-images.githubusercontent.com/15830521/47366734-95da5e00-d6de-11e8-92d4-0bf9c219c11d.png)


Take advantage of this and also change some sizes to match the screen scale factor. Also fix some values when dividing, that can become decimal instead of integers.